### PR TITLE
Allow websub-only feeds

### DIFF
--- a/pushl/__init__.py
+++ b/pushl/__init__.py
@@ -28,7 +28,7 @@ class Pushl:
 
         self.session = session
 
-    async def process_feed(self, url):
+    async def process_feed(self, url, send_mentions=True):
         """ process a feed """
 
         self._feed_domains.add(utils.get_domain(url))
@@ -48,7 +48,7 @@ class Pushl:
         if not feed:
             return
 
-        LOGGER.debug("--- starting process_feed %s", url)
+        LOGGER.debug("--- starting process_feed %s %s", url, send_mentions)
 
         pending = []
 
@@ -65,7 +65,7 @@ class Pushl:
                                                              'next-page'):
                     LOGGER.debug("Found archive link %s", link)
                     pending.append(
-                        ("process feed " + href, self.process_feed(href)))
+                        ("process feed " + href, self.process_feed(href, send_mentions)))
 
                 # WebSub notification
                 if updated and link.get('rel') == 'hub' and not feed.is_archive:
@@ -81,9 +81,9 @@ class Pushl:
             items |= set(previous.entry_links)
         for entry in items:
             pending.append(("process entry " + entry,
-                            self.process_entry(entry)))
+                            self.process_entry(entry, send_mentions=send_mentions)))
 
-        LOGGER.debug("--- finish process_feed %s", url)
+        LOGGER.debug("--- finish process_feed %s %s", url, send_mentions)
 
         if pending:
             LOGGER.debug("+++WAIT: process_feed(%s): %d subtasks",
@@ -93,7 +93,7 @@ class Pushl:
             LOGGER.debug("+++DONE: process_feed(%s): %d subtasks",
                          url, len(pending))
 
-    async def process_entry(self, url, add_domain=False):
+    async def process_entry(self, url, add_domain=False, send_mentions=True):
         """ process an entry """
 
         if add_domain:
@@ -113,21 +113,22 @@ class Pushl:
         pending = []
 
         if updated:
-            # get the webmention targets
-            links = entry.get_targets(self)
-            if previous:
-                # Only bother with links that changed from the last time
-                links = links ^ previous.get_targets(self)
+            if send_mentions:
+                # get the webmention targets
+                links = entry.get_targets(self)
+                if previous:
+                    # Only bother with links that changed from the last time
+                    links = links ^ previous.get_targets(self)
 
-            for link in links:
-                pending.append(("send webmention {} -> {}".format(url, link),
-                                self.send_webmention(entry, link)))
+                for link in links:
+                    pending.append(("send webmention {} -> {}".format(url, link),
+                                    self.send_webmention(entry, link)))
 
             if self.args.recurse:
                 for feed in entry.feeds:
                     if utils.get_domain(feed) in self._feed_domains:
                         pending.append(("process feed " + feed,
-                                        self.process_feed(feed)))
+                                        self.process_feed(feed, send_mentions=send_mentions)))
 
         LOGGER.debug("--- finish process_entry %s", url)
 

--- a/pushl/__main__.py
+++ b/pushl/__main__.py
@@ -35,6 +35,9 @@ def parse_args(*args):
                         help='URLs to entries/pages to index directly',
                         metavar='entry_url',
                         dest='entries')
+    parser.add_argument("-s", "--websub-only", nargs='+',
+                        help='URLs/feeds to only send WebSub notifications for',
+                        metavar='feed_url', dest='websub_only')
     parser.add_argument('--timeout', '-t', type=int, dest='timeout',
                         help='Connection timeout, in seconds',
                         default=120)
@@ -120,6 +123,9 @@ async def _run(args):
         tasks = []
         for url in args.feeds or []:
             tasks.append(worker.process_feed(url))
+
+        for url in args.websub_only or []:
+            tasks.append(worker.process_feed(url, False))
 
         for url in args.entries or []:
             tasks.append(worker.process_entry(url, add_domain=True))


### PR DESCRIPTION
Make it so that you can configure a feed to only send WebSub notifications, rather than WebSub+WebMention.

Fixes #10 