### PR TITLE
Support mf2 h-entry as a feed source

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d17a3dd92c716ba025c71c0d324cd69da85460ba9114fe3b0ec9c18e3442448f"
+            "sha256": "abd7206e8f266d42708b780b65893a70a9bfe0b3d3821b4e9fd982bc48021fa1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -67,6 +67,13 @@
             ],
             "version": "==4.8.1"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+            ],
+            "version": "==2019.11.28"
+        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
@@ -81,6 +88,13 @@
                 "sha256:ce875495c90ebd74b179855449040003a1beb40cd13d5f037a0654251e260b02"
             ],
             "version": "==5.2.1"
+        },
+        "html5lib": {
+            "hashes": [
+                "sha256:20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3",
+                "sha256:66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736"
+            ],
+            "version": "==1.0.1"
         },
         "idna": {
             "hashes": [
@@ -119,6 +133,13 @@
                 "sha256:f6ed60a62c5f1c44e789d2cf14009423cb1646b44a43e40a9cf6a21f077678a1"
             ],
             "version": "==4.4.2"
+        },
+        "mf2py": {
+            "hashes": [
+                "sha256:84f1f8f2ff3f1deb1c30be497e7ccd805452996a662fd4a77f09e0105bede2c9"
+            ],
+            "index": "pypi",
+            "version": "==1.1.2"
         },
         "multidict": {
             "hashes": [
@@ -164,6 +185,20 @@
             ],
             "version": "==2019.11.1"
         },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "version": "==2.22.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+            ],
+            "version": "==1.13.0"
+        },
         "soupsieve": {
             "hashes": [
                 "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5",
@@ -177,6 +212,20 @@
                 "sha256:61f807220eda0203a774a09f84b4304a3f93b5944110cc132af29ddb81366883"
             ],
             "version": "==0.4.21"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
+                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+            ],
+            "version": "==1.25.7"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         },
         "yarl": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ See http://publ.beesbuzz.biz/blog/113-Some-thoughts-on-WebMention for the motiva
 
 ## Features
 
+* Supports any feed supported by [feedparser](https://github.com/kurtmckee/feedparser)
+    and [mf2py](https://github.com/microformats/mf2py) (RSS, Atom, HTML pages containing
+    `h-entry`, etc.)
 * Will send WebSub notifications for feeds which declare a WebSub hub
 * Will send WebMention notifications for entries discovered on those feeds or specified directly
 * Can perform autodiscovery of additional feeds on entry pages
@@ -15,7 +18,7 @@ See http://publ.beesbuzz.biz/blog/113-Some-thoughts-on-WebMention for the motiva
 
 ## Site setup
 
-First, you'll want to have your Atom (or RSS) feed implement [the WebSub protocol](https://indieweb.org/WebSub). The short version is that you should have a `<link rel="hub" href="http://path/to/hub" />` in your feed's top-level element.
+If you want to support WebSub, have your feed implement [the WebSub protocol](https://indieweb.org/WebSub). The short version is that you should have a `<link rel="hub" href="http://path/to/hub" />` in your feed's top-level element.
 
 There are a number of WebSub hubs available; I use [Superfeedr](http://pubsubhubbub.superfeedr.com).
 
@@ -26,6 +29,12 @@ For [WebMentions](https://indieweb.org/Webmention), configure your site template
 * Anything with a `class` of `entry`
 
 For more information on how to configure your site templates, see the [microformats h-entry specification](http://microformats.org/wiki/h-entry).
+
+### mf2 feed notes
+
+If you're using an mf2 feed (i.e. an HTML-formatted page with `h-entry` declarations), only entries with a `u-url` property will be used for sending webmentions; further, Pushl will retrieve the page from that URL to ensure it has the full content. (This is to work around certain setups where the `h-feed` only shows summary text.)
+
+Also, there is technically no requirement for an HTML page to declare an `h-feed`; all entities marked up with `h-entry` will be consumed.
 
 ## Installation
 
@@ -78,7 +87,7 @@ Note that `-r` and `-e` in conjunction will also cause the feed declared on the 
 pushl -re http://example.com/blog/
 ```
 
-this will also send webmentions from the blog page itself which is probably *not* what you want to do.
+this will also send webmentions from the blog page itself which is probably *not* what you want to have happen.
 
 ### Backfilling old content
 

--- a/pushl/__init__.py
+++ b/pushl/__init__.py
@@ -202,6 +202,10 @@ class Pushl:
                             utils.retry_get(self, 'https://web.archive.org/save/' + dest)))
             self._processed_wayback.add(dest)
 
+        if self.args.dry_run:
+            LOGGER.info("DRY RUN: not sending ping %s -> %s", entry_url, dest)
+            return
+
         await self._run_pending(pending, 'send_webmention(%s,%s)' % (entry_url, dest))
 
     async def send_websub(self, url: str, hub: str):
@@ -212,5 +216,8 @@ class Pushl:
                 "Skipping already processed websub %s -> %s", url, hub)
             return
         self._processed_websub.add((url, hub))
+
+        if self.args.dry_run:
+            LOGGER.info("DRY RUN: not sending websub %s -> %s", url, hub)
 
         await websub.send(self, url, hub)

--- a/pushl/__main__.py
+++ b/pushl/__main__.py
@@ -103,6 +103,15 @@ def parse_args(*args):
                          dest='self_pings', action='store_false')
     feature.set_defaults(self_pings=False)
 
+    feature = parser.add_mutually_exclusive_group(required=False)
+    feature.add_argument('--dry-run', '-n',
+                         help="Only perform a dry run; don't send any pings",
+                         dest='dry_run', action='store_true')
+    feature.add_argument('--no-dry-run',
+                         help="Send pings normally",
+                         dest='dry_run', action='store_false')
+    feature.set_defaults(dry_run=False)
+
     return parser.parse_args(*args)
 
 

--- a/pushl/entries.py
+++ b/pushl/entries.py
@@ -41,6 +41,7 @@ class Entry:
             self.feeds = [urllib.parse.urljoin(self.url, link.attrs['href'])
                           for link
                           in soup.find_all('link',
+                                           rel="alternate",
                                            href=True,
                                            type={'text/xml',
                                                  'application/rdf+xml',
@@ -48,6 +49,9 @@ class Entry:
                                                  'application/atom+xml',
                                                  'application/xml'}
                                            )]
+            self.feeds += [urllib.parse.urljoin(self.url, link.attrs['href'])
+                           for link
+                           in soup.find_all('link', rel="hub")]
 
             self.hubs = [link.attrs['href']
                          for link in soup.find_all('link', rel='hub', href=True)]

--- a/setup.py
+++ b/setup.py
@@ -57,12 +57,13 @@ setup(
     packages=['pushl'],
 
     install_requires=[
-        'feedparser',
-        'beautifulsoup4',
-        'awesome-slugify',
         'aiohttp',
+        'async_lru',
+        'awesome-slugify',
+        'beautifulsoup4',
+        'feedparser',
         'lxml',
-        'async_lru'
+        'mf2py',
     ],
 
     extras_require={


### PR DESCRIPTION
Fixes #24 

Since there's so much variability in IndieWeb usage of `h-feed` et al it was easier to simply see if feedparser failed to consume the Atom/RSS feed, and if so, parse it through `mf2py`, adding all `h-entry` items with a `url` property to the entry list.

While I was making mf2 entries' urls relative, I went ahead and resolved relative URLs from RSS/Atom feeds as well, which potentially fixes Pushl for feeds which improperly provide relative rather than absolute `<link>`s.